### PR TITLE
Add MiniMax provider profile with region-aware endpoints and thinking modes

### DIFF
--- a/config.full-example.toml
+++ b/config.full-example.toml
@@ -17,6 +17,16 @@ model = "glm-4.1v-9b-thinking"  # The vision model used for image analysis tasks
 base_url = "https://open.bigmodel.cn/api/paas/v4/"  # Base URL for the vision model API service
 api_key = "<YOUR API KEY>"  # API key for accessing the vision model
 
+### Optional: select a non-default model provider.
+### When provider = "minimax", base_url may be omitted and is resolved from region
+### ("global_en" -> https://api.minimax.io/v1, "cn_zh" -> https://api.minimaxi.com/v1).
+### MiniMax-M3 supports "adaptive"/"disabled" thinking; MiniMax-M2.7 always reasons.
+# [llm.chat]
+# provider = "minimax"       # Provider identifier; defaults to "openai" when omitted
+# region = "global_en"       # Region profile: "global_en" or "cn_zh"
+# model = "MiniMax-M3"        # MiniMax-M3 or MiniMax-M2.7
+# api_key = "<YOUR API KEY>"  # API key for the selected provider
+
 [rerank]
 rerank_model = "bge-reranker-v2-m3"  # The reranking model used to improve search result relevance
 rerank_api_key = "<YOUR API KEY>" # API key for accessing the reranking model (infiniai service)

--- a/openlens_ai/agents/coder.py
+++ b/openlens_ai/agents/coder.py
@@ -6,7 +6,7 @@ from loguru import logger
 import traceback
 
 from langgraph.graph import StateGraph, START, END
-from langchain.chat_models import init_chat_model
+from ..utils.llm_provider import build_chat_model
 from langchain_core.messages import ToolMessage, AIMessage, HumanMessage
 
 from file1agent.file_manager import FileManager
@@ -46,20 +46,8 @@ def build_coder(config: Config, file_manager: FileManager) -> StateGraph:
     coder_concluder_prompt = load_prompt_file(config, "coder_concluder.md")
     coder_router_prompt = load_prompt_file(config, "coder_router.md")
     
-    concluder_llm = init_chat_model(
-        config.llm.chat.model,
-        base_url=config.llm.chat.base_url,
-        model_provider="openai",
-        openai_api_key=config.llm.chat.api_key,
-        extra_body={"chat_template_kwargs": {"enable_thinking": False}},
-    )
-    router_llm = init_chat_model(
-        config.llm.chat.model,
-        base_url=config.llm.chat.base_url,
-        model_provider="openai",
-        openai_api_key=config.llm.chat.api_key,
-        extra_body={"chat_template_kwargs": {"enable_thinking": False}},
-    )
+    concluder_llm = build_chat_model(config.llm.chat, enable_thinking=False)
+    router_llm = build_chat_model(config.llm.chat, enable_thinking=False)
     
     plan_reader_tool = PlanReaderTool(config.save_path)
     report_writer_tool = ReportWriterTool(config.save_path)

--- a/openlens_ai/agents/data_analyzer.py
+++ b/openlens_ai/agents/data_analyzer.py
@@ -7,7 +7,7 @@ from loguru import logger
 import traceback
 
 from langgraph.graph import StateGraph, START, END
-from langchain.chat_models import init_chat_model
+from ..utils.llm_provider import build_chat_model
 from langchain_tavily import TavilySearch
 from langchain_core.messages import ToolMessage, HumanMessage, AIMessage
 
@@ -46,13 +46,7 @@ def build_data_analyzer(config: Config, file_manager: FileManager) -> StateGraph
     # Load prompts based on domain configuration
     data_report_prompt = load_prompt_file(config, "data_report.md")
 
-    llm = init_chat_model(
-        config.llm.chat.model,
-        base_url=config.llm.chat.base_url,
-        model_provider="openai",
-        openai_api_key=config.llm.chat.api_key,
-        extra_body={"chat_template_kwargs": {"enable_thinking": True}},
-    )
+    llm = build_chat_model(config.llm.chat, enable_thinking=True)
     # report_writer_tool = ReportWriterTool(config.save_path, file_name="data_report.md")
     # tools = [report_writer_tool]
     # llm_with_tools = llm.bind_tools(tools)

--- a/openlens_ai/agents/latex_writer.py
+++ b/openlens_ai/agents/latex_writer.py
@@ -6,7 +6,7 @@ from loguru import logger
 import traceback
 
 from langgraph.graph import StateGraph, START, END
-from langchain.chat_models import init_chat_model
+from ..utils.llm_provider import build_chat_model
 from langchain_core.messages import ToolMessage, AIMessage, HumanMessage
 
 from file1agent.file_manager import FileManager
@@ -73,20 +73,8 @@ def build_latex_writer(config: Config, file_manager: FileManager) -> StateGraph:
     latex_literature_check_prompt = load_prompt_file(config, "latex_literature_check.md")
     latex_figure_check_prompt = load_prompt_file(config, "latex_figure_check.md")
 
-    concluder_llm = init_chat_model(
-        config.llm.chat.model,
-        base_url=config.llm.chat.base_url,
-        model_provider="openai",
-        openai_api_key=config.llm.chat.api_key,
-        extra_body={"chat_template_kwargs": {"enable_thinking": True}},
-    )
-    router_llm = init_chat_model(
-        config.llm.chat.model,
-        base_url=config.llm.chat.base_url,
-        model_provider="openai",
-        openai_api_key=config.llm.chat.api_key,
-        extra_body={"chat_template_kwargs": {"enable_thinking": True}},
-    )
+    concluder_llm = build_chat_model(config.llm.chat, enable_thinking=True)
+    router_llm = build_chat_model(config.llm.chat, enable_thinking=True)
 
     report_writer_tool = ReportWriterTool(config.save_path, file_name="manuscript/latex_quality_report.md")
 

--- a/openlens_ai/agents/literature_reviewer.py
+++ b/openlens_ai/agents/literature_reviewer.py
@@ -5,7 +5,7 @@ import os
 from loguru import logger
 import asyncio
 
-from langchain.chat_models import init_chat_model
+from ..utils.llm_provider import build_chat_model
 from langgraph.graph import StateGraph, END, START
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from langgraph.prebuilt import create_react_agent
@@ -63,20 +63,8 @@ def build_literature_review_subgraph(config: Config, file_manager: FileManager):
     search_prompt_template = load_prompt_file(config, "literature_search.md")
 
     # 初始化语言模型
-    search_llm = init_chat_model(
-        config.llm.chat.model,
-        base_url=config.llm.chat.base_url,
-        model_provider="openai",
-        openai_api_key=config.llm.chat.api_key,
-        extra_body={"chat_template_kwargs": {"enable_thinking": True}},
-    )
-    write_llm = init_chat_model(
-        config.llm.chat.model,
-        base_url=config.llm.chat.base_url,
-        model_provider="openai",
-        openai_api_key=config.llm.chat.api_key,
-        extra_body={"chat_template_kwargs": {"enable_thinking": True}},
-    )
+    search_llm = build_chat_model(config.llm.chat, enable_thinking=True)
+    write_llm = build_chat_model(config.llm.chat, enable_thinking=True)
     search_tools = [
         SearchArxivTool(),
         ReadArxivPaperTool(),

--- a/openlens_ai/agents/supervisor.py
+++ b/openlens_ai/agents/supervisor.py
@@ -5,7 +5,7 @@ from typing_extensions import TypedDict
 
 
 from langgraph.graph import StateGraph, START, END
-from langchain.chat_models import init_chat_model
+from ..utils.llm_provider import build_chat_model
 from langchain_tavily import TavilySearch
 
 from file1agent.file_manager import FileManager
@@ -50,13 +50,7 @@ def build_supervisor(config: Config, file_manager: FileManager) -> StateGraph:
         state["current_subtask_index"] = 1
         return state
 
-    llm = init_chat_model(
-        config.llm.chat.model,
-        base_url=config.llm.chat.base_url,
-        model_provider="openai",
-        openai_api_key=config.llm.chat.api_key,
-        extra_body={"chat_template_kwargs": {"enable_thinking": True}},
-    )
+    llm = build_chat_model(config.llm.chat, enable_thinking=True)
     llm_with_tools = llm.bind_tools(tools)
     chatbot = chatbot_with_context_manager(config, llm_with_tools, prompt, calling_subgraph="supervisor")
     alter_chatbot = chatbot_with_context_manager(config, llm_with_tools, alter_prompt, calling_subgraph="supervisor")

--- a/openlens_ai/utils/config.py
+++ b/openlens_ai/utils/config.py
@@ -12,6 +12,8 @@ class ModelConfig(BaseModel):
     model: str = Field(default="", description="Chat model name")
     base_url: Optional[str] = Field(default=None, description="Base URL for API")
     api_key: Optional[str] = Field(default=None, description="API key for chat service")
+    provider: str = Field(default="openai", description="Model provider identifier, e.g. 'openai' or 'minimax'")
+    region: Optional[str] = Field(default=None, description="Provider region profile (e.g. 'global_en' or 'cn_zh') used to resolve the base URL when it is not set explicitly")
 
 class LLMConfig(BaseModel):
     """Language model configuration"""

--- a/openlens_ai/utils/llm_provider.py
+++ b/openlens_ai/utils/llm_provider.py
@@ -1,0 +1,148 @@
+"""Provider-aware construction of chat and vision clients.
+
+Historically every chat and vision client was created with a hard-coded
+``model_provider="openai"`` together with a backend-specific
+``extra_body={"chat_template_kwargs": {"enable_thinking": ...}}`` payload. That
+payload is only understood by OpenAI-compatible open-weight backends that gate
+reasoning through the chat template, and it does not describe how other
+providers express their reasoning ("thinking") behaviour.
+
+This module introduces a small provider registry so the agents can target
+different providers, resolve their regional base URLs, and translate a single
+"enable thinking" intent into the reasoning control each provider/model
+actually supports. The default provider keeps the previous behaviour byte for
+byte, so existing configurations are unaffected.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .config import ModelConfig
+
+DEFAULT_PROVIDER = "openai"
+
+# MiniMax regional endpoint profiles. The global and mainland-China clusters are
+# served from different hosts, so the base URL is resolved from the selected
+# region when it is not set explicitly on the model configuration.
+MINIMAX_REGIONS: dict[str, dict[str, str]] = {
+    "global_en": {
+        "openai_base_url": "https://api.minimax.io/v1",
+        "anthropic_base_url": "https://api.minimax.io/anthropic",
+        "docs_root": "https://platform.minimax.io/docs",
+    },
+    "cn_zh": {
+        "openai_base_url": "https://api.minimaxi.com/v1",
+        "anthropic_base_url": "https://api.minimaxi.com/anthropic",
+        "docs_root": "https://platform.minimaxi.com/docs",
+    },
+}
+MINIMAX_DEFAULT_REGION = "global_en"
+
+# Per-model reasoning ("thinking") capabilities for the MiniMax provider. The
+# tuple lists the thinking modes each model supports; the first entry is used as
+# the fallback when a requested mode is unavailable.
+MINIMAX_MODEL_THINKING: dict[str, tuple[str, ...]] = {
+    "MiniMax-M3": ("adaptive", "disabled"),
+    "MiniMax-M2.7": ("always_on",),
+}
+
+
+def normalize_provider(provider: Optional[str]) -> str:
+    """Return a canonical provider identifier, defaulting to ``openai``."""
+    return (provider or DEFAULT_PROVIDER).strip().lower()
+
+
+def resolve_minimax_region(region: Optional[str]) -> str:
+    """Return a known MiniMax region key, defaulting to the global cluster."""
+    key = (region or MINIMAX_DEFAULT_REGION).strip().lower()
+    if key not in MINIMAX_REGIONS:
+        raise ValueError(
+            f"Unknown MiniMax region {region!r}; expected one of {sorted(MINIMAX_REGIONS)}"
+        )
+    return key
+
+
+def minimax_base_url(region: Optional[str]) -> str:
+    """Return the OpenAI-compatible MiniMax base URL for ``region``."""
+    return MINIMAX_REGIONS[resolve_minimax_region(region)]["openai_base_url"]
+
+
+def resolve_minimax_thinking_mode(model: str, enable_thinking: bool) -> Optional[str]:
+    """Map an ``enable_thinking`` intent onto a MiniMax model's thinking mode.
+
+    Returns ``None`` for models with no registered thinking capability. Models
+    whose only mode is ``always_on`` always reason and expose no toggle, so the
+    caller should not send any thinking control for them.
+    """
+    modes = MINIMAX_MODEL_THINKING.get(model)
+    if not modes:
+        return None
+    if "always_on" in modes:
+        return "always_on"
+    if enable_thinking:
+        return "adaptive" if "adaptive" in modes else modes[0]
+    return "disabled" if "disabled" in modes else modes[0]
+
+
+def build_extra_body(
+    provider: Optional[str],
+    model: str,
+    enable_thinking: bool,
+    max_tokens: Optional[int] = None,
+) -> dict[str, Any]:
+    """Build the ``extra_body`` request payload for the given provider/model."""
+    extra: dict[str, Any] = {}
+    if normalize_provider(provider) == "minimax":
+        mode = resolve_minimax_thinking_mode(model, enable_thinking)
+        # ``always_on`` models cannot be toggled, so no thinking control is sent.
+        if mode in ("adaptive", "disabled"):
+            extra["thinking"] = {"type": mode}
+    else:
+        # OpenAI-compatible open-weight backends gate reasoning through the chat
+        # template rather than a first-class request field.
+        extra["chat_template_kwargs"] = {"enable_thinking": enable_thinking}
+        if max_tokens is not None:
+            extra["max_tokens"] = max_tokens
+    return extra
+
+
+def resolve_base_url(provider: Optional[str], model_cfg: "ModelConfig") -> Optional[str]:
+    """Resolve the base URL, falling back to the MiniMax regional endpoint."""
+    if getattr(model_cfg, "base_url", None):
+        return model_cfg.base_url
+    if normalize_provider(provider) == "minimax":
+        return minimax_base_url(getattr(model_cfg, "region", None))
+    return None
+
+
+def build_chat_model(
+    model_cfg: "ModelConfig",
+    *,
+    enable_thinking: bool,
+    max_tokens: Optional[int] = None,
+):
+    """Create a chat/vision client for ``model_cfg`` in a provider-aware way.
+
+    The provider is read from ``model_cfg.provider`` (default ``openai``). All
+    supported providers currently speak the OpenAI-compatible protocol, so the
+    LangChain ``openai`` adapter is used while the reasoning payload and base URL
+    are derived from the selected provider.
+    """
+    from langchain.chat_models import init_chat_model
+
+    provider = normalize_provider(getattr(model_cfg, "provider", None))
+    init_kwargs: dict[str, Any] = {
+        "base_url": resolve_base_url(provider, model_cfg),
+        "model_provider": "openai",
+        "openai_api_key": getattr(model_cfg, "api_key", None),
+    }
+    if max_tokens is not None:
+        init_kwargs["max_tokens"] = max_tokens
+    extra_body = build_extra_body(
+        provider, getattr(model_cfg, "model", ""), enable_thinking, max_tokens=max_tokens
+    )
+    if extra_body:
+        init_kwargs["extra_body"] = extra_body
+    return init_chat_model(model_cfg.model, **init_kwargs)

--- a/openlens_ai/utils/vision_feedback.py
+++ b/openlens_ai/utils/vision_feedback.py
@@ -16,7 +16,7 @@ try:
     from langchain_core.load.dump import dumps
 except ImportError:
     from langchain.load.dump import dumps
-from langchain.chat_models import init_chat_model
+from .llm_provider import build_chat_model
 from langchain_core.messages import ToolMessage, AIMessage, HumanMessage
 
 from ..utils.config import Config, get_lang_prompt
@@ -66,13 +66,10 @@ def compress_image(img_data, max_size=4000):
 
 
 def get_vlm(config: Config):
-    return init_chat_model(
-        config.llm.vision.model,
-        base_url=config.llm.vision.base_url,
-        model_provider="openai",
-        openai_api_key=config.llm.vision.api_key,
+    return build_chat_model(
+        config.llm.vision,
+        enable_thinking=True,
         max_tokens=config.context.max_context_token_cnt,
-        extra_body={"chat_template_kwargs": {"enable_thinking": True}, "max_tokens": config.context.max_context_token_cnt},
     )
 
 

--- a/tests/unit/test_llm_provider.py
+++ b/tests/unit/test_llm_provider.py
@@ -1,0 +1,86 @@
+import unittest
+
+from openlens_ai.utils.llm_provider import (
+    MINIMAX_DEFAULT_REGION,
+    MINIMAX_REGIONS,
+    build_extra_body,
+    minimax_base_url,
+    normalize_provider,
+    resolve_minimax_region,
+    resolve_minimax_thinking_mode,
+)
+
+
+class TestLLMProvider(unittest.TestCase):
+    """Unit tests for the provider-aware client helpers."""
+
+    def test_normalize_provider_defaults_and_case(self):
+        self.assertEqual(normalize_provider(None), "openai")
+        self.assertEqual(normalize_provider(""), "openai")
+        self.assertEqual(normalize_provider("  MiniMax "), "minimax")
+
+    def test_minimax_regions_endpoints(self):
+        self.assertEqual(minimax_base_url("global_en"), "https://api.minimax.io/v1")
+        self.assertEqual(minimax_base_url("cn_zh"), "https://api.minimaxi.com/v1")
+        self.assertEqual(
+            MINIMAX_REGIONS["global_en"]["anthropic_base_url"],
+            "https://api.minimax.io/anthropic",
+        )
+        self.assertEqual(
+            MINIMAX_REGIONS["cn_zh"]["anthropic_base_url"],
+            "https://api.minimaxi.com/anthropic",
+        )
+
+    def test_resolve_minimax_region(self):
+        self.assertEqual(resolve_minimax_region(None), MINIMAX_DEFAULT_REGION)
+        self.assertEqual(resolve_minimax_region("CN_ZH"), "cn_zh")
+        with self.assertRaises(ValueError):
+            resolve_minimax_region("mars")
+
+    def test_thinking_mode_adaptive_disabled_model(self):
+        self.assertEqual(resolve_minimax_thinking_mode("MiniMax-M3", True), "adaptive")
+        self.assertEqual(resolve_minimax_thinking_mode("MiniMax-M3", False), "disabled")
+
+    def test_thinking_mode_always_on_model(self):
+        self.assertEqual(resolve_minimax_thinking_mode("MiniMax-M2.7", True), "always_on")
+        self.assertEqual(resolve_minimax_thinking_mode("MiniMax-M2.7", False), "always_on")
+
+    def test_thinking_mode_unknown_model(self):
+        self.assertIsNone(resolve_minimax_thinking_mode("unknown-model", True))
+
+    def test_extra_body_openai_default_matches_legacy_payload(self):
+        self.assertEqual(
+            build_extra_body("openai", "any-model", True),
+            {"chat_template_kwargs": {"enable_thinking": True}},
+        )
+        self.assertEqual(
+            build_extra_body(None, "any-model", False),
+            {"chat_template_kwargs": {"enable_thinking": False}},
+        )
+
+    def test_extra_body_openai_with_max_tokens(self):
+        self.assertEqual(
+            build_extra_body("openai", "any-model", True, max_tokens=1234),
+            {"chat_template_kwargs": {"enable_thinking": True}, "max_tokens": 1234},
+        )
+
+    def test_extra_body_minimax_toggleable_model(self):
+        self.assertEqual(
+            build_extra_body("minimax", "MiniMax-M3", True),
+            {"thinking": {"type": "adaptive"}},
+        )
+        self.assertEqual(
+            build_extra_body("minimax", "MiniMax-M3", False),
+            {"thinking": {"type": "disabled"}},
+        )
+
+    def test_extra_body_minimax_always_on_sends_no_thinking_control(self):
+        self.assertEqual(build_extra_body("minimax", "MiniMax-M2.7", True), {})
+        self.assertEqual(build_extra_body("minimax", "MiniMax-M2.7", False), {})
+
+    def test_extra_body_minimax_never_uses_chat_template_kwargs(self):
+        self.assertNotIn("chat_template_kwargs", build_extra_body("minimax", "MiniMax-M3", True))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reason: Chat and vision clients were hard-wired to a single provider with a backend-specific thinking payload, so the MiniMax provider, its global/CN endpoints, and MiniMax-M3 / MiniMax-M2.7 thinking behaviour could not be selected.

## Changes
- Add `openlens_ai/utils/llm_provider.py`, a small provider registry that resolves the base URL and the reasoning ("thinking") request payload per provider/model, plus a `build_chat_model()` factory shared by every chat and vision client.
- Register the MiniMax provider: global (`https://api.minimax.io/v1`) and mainland-China (`https://api.minimaxi.com/v1`) endpoint profiles, and per-model thinking capabilities — MiniMax-M3 (`adaptive`/`disabled`) and MiniMax-M2.7 (`always_on`, which exposes no toggle).
- Add `provider` and `region` fields to `ModelConfig`; when `provider = "minimax"` the base URL is resolved from `region` if it is not set explicitly.
- Route the supervisor, data analyzer, literature reviewer, LaTeX writer, coder, and vision-feedback clients through the factory. The default `openai` provider keeps the previous request payload byte for byte, so existing configurations are unaffected.
- Document the MiniMax profile in `config.full-example.toml` and add offline unit tests in `tests/unit/test_llm_provider.py`.

## Checks
- `ruff check --select E9,F openlens_ai/utils/llm_provider.py tests/unit/test_llm_provider.py` — clean.
- `ruff check --select E9` across all changed files — clean (no syntax errors introduced).
- `python -m pytest tests/unit/test_llm_provider.py` — 11 passed.
