### PR TITLE
Add MiniMax-M3 video input formatting

### DIFF
--- a/openlens_ai/utils/llm_provider.py
+++ b/openlens_ai/utils/llm_provider.py
@@ -48,6 +48,18 @@ MINIMAX_MODEL_THINKING: dict[str, tuple[str, ...]] = {
     "MiniMax-M2.7": ("always_on",),
 }
 
+# Input capabilities are kept with the provider profile so request formatting
+# can reject unsupported media before making a remote call.
+MINIMAX_MODEL_INPUT_MODALITIES: dict[str, tuple[str, ...]] = {
+    "MiniMax-M3": ("text", "image", "video"),
+    "MiniMax-M2.7": ("text",),
+}
+
+MULTIMODAL_CONTENT_TYPES = {
+    "image": "image_url",
+    "video": "video_url",
+}
+
 
 def normalize_provider(provider: Optional[str]) -> str:
     """Return a canonical provider identifier, defaulting to ``openai``."""
@@ -84,6 +96,45 @@ def resolve_minimax_thinking_mode(model: str, enable_thinking: bool) -> Optional
     if enable_thinking:
         return "adaptive" if "adaptive" in modes else modes[0]
     return "disabled" if "disabled" in modes else modes[0]
+
+
+def minimax_input_modalities(model: str) -> tuple[str, ...]:
+    """Return the registered input modalities for a MiniMax model."""
+    return MINIMAX_MODEL_INPUT_MODALITIES.get(model, ("text",))
+
+
+def build_multimodal_message(
+    provider: Optional[str],
+    model: str,
+    prompt: str,
+    media: Optional[str] = None,
+    media_type: str = "text",
+) -> list[dict[str, Any]]:
+    """Build one user message containing text and optional image or video input."""
+    modality = media_type.strip().lower()
+    if normalize_provider(provider) == "minimax":
+        supported = minimax_input_modalities(model)
+        if modality not in supported:
+            raise ValueError(
+                f"MiniMax model {model!r} does not support {modality!r} input; "
+                f"expected one of {supported}"
+            )
+
+    content: list[dict[str, Any]] = [{"type": "text", "text": prompt}]
+    if modality == "text":
+        return [{"role": "user", "content": content}]
+
+    content_type = MULTIMODAL_CONTENT_TYPES.get(modality)
+    if content_type is None:
+        raise ValueError(f"Unsupported media input type: {media_type!r}")
+    if not media:
+        raise ValueError(f"{modality} input requires a URL or data URI")
+
+    media_url = media
+    if modality == "image" and not media.startswith(("data:", "http://", "https://")):
+        media_url = f"data:image/png;base64,{media}"
+    content.append({"type": content_type, content_type: {"url": media_url}})
+    return [{"role": "user", "content": content}]
 
 
 def build_extra_body(

--- a/openlens_ai/utils/vision_feedback.py
+++ b/openlens_ai/utils/vision_feedback.py
@@ -16,7 +16,7 @@ try:
     from langchain_core.load.dump import dumps
 except ImportError:
     from langchain.load.dump import dumps
-from .llm_provider import build_chat_model
+from .llm_provider import build_chat_model, build_multimodal_message
 from langchain_core.messages import ToolMessage, AIMessage, HumanMessage
 
 from ..utils.config import Config, get_lang_prompt
@@ -346,35 +346,20 @@ def save_llm_call(messages: list, config: Config):
 
 
 
-base64_prefix_png = "data:image/png;base64,"
-MSG_FORMATTERS = [
-    # Formatter A: Standard OpenAI format
-    lambda p, img: [
-        {
-            "role": "user",
-            "content": [{"type": "text", "text": p}, {"type": "image_url", "image_url": {"url": img if img.startswith("data:") else base64_prefix_png + img}}],
-        }
-    ],
-    # # Formatter B: Alternative format for some models
-    # lambda p, img: [
-    #     {
-    #         "role": "user",
-    #         "content": [
-    #             {"type": "text", "text": p},
-    #             {"type": "image", "source_type": "base64", "data": img, "mime_type": "image/jpeg"},
-    #         ],
-    #     }
-    # ],
-]
-
-def call_vlm_with_prompt(config: Config, image_base64: str, prompt: str) -> str:
+def call_vlm_with_prompt(
+    config: Config,
+    media: str,
+    prompt: str,
+    media_type: str = "image",
+) -> str:
     """
     Generic VLM calling function for handling image-related requests
 
     Args:
-        image_base64: Base64 encoded image data
+        media: Media URL, data URI, or base64-encoded image data
         config: Configuration object
         prompt: Prompt text
+        media_type: Input modality, either ``image`` or ``video``
 
     Returns:
         VLM response content
@@ -382,26 +367,32 @@ def call_vlm_with_prompt(config: Config, image_base64: str, prompt: str) -> str:
 
     vlm = get_vlm(config)
 
-    # Select formatter to use
-    formatters = MSG_FORMATTERS
     error_msg = ""
     for try_i in range(3):
-        for this_formatter in formatters:
-            try:
-                # Call VLM to evaluate the image
-                image_message = this_formatter(prompt, image_base64)
-
-                vlm_response = vlm.invoke(image_message)
-                save_llm_call(image_message + [vlm_response], config)
-                logger.debug(f"Vision response: {vlm_response.content}")
-                return vlm_response.content
-            except Exception as e:
-                error_msg = f"Error when calling llm: {e}"
-                logger.warning(f"Error when calling llm: {e}")
-                logger.warning(traceback.format_exc())
-                logger.warning("Retrying...")
-                time.sleep(5)
+        try:
+            media_message = build_multimodal_message(
+                config.llm.vision.provider,
+                config.llm.vision.model,
+                prompt,
+                media,
+                media_type,
+            )
+            vlm_response = vlm.invoke(media_message)
+            save_llm_call(media_message + [vlm_response], config)
+            logger.debug(f"Vision response: {vlm_response.content}")
+            return vlm_response.content
+        except Exception as e:
+            error_msg = f"Error when calling llm: {e}"
+            logger.warning(f"Error when calling llm: {e}")
+            logger.warning(traceback.format_exc())
+            logger.warning("Retrying...")
+            time.sleep(5)
     return error_msg
+
+
+def call_video_vlm_with_prompt(config: Config, video_url: str, prompt: str) -> str:
+    """Call a video-capable vision model with a remote video URL."""
+    return call_vlm_with_prompt(config, video_url, prompt, media_type="video")
 
 
 def _load_prompt(config: Config, prompt_filename: str) -> str:

--- a/tests/unit/test_llm_provider.py
+++ b/tests/unit/test_llm_provider.py
@@ -2,9 +2,12 @@ import unittest
 
 from openlens_ai.utils.llm_provider import (
     MINIMAX_DEFAULT_REGION,
+    MINIMAX_MODEL_INPUT_MODALITIES,
     MINIMAX_REGIONS,
+    build_multimodal_message,
     build_extra_body,
     minimax_base_url,
+    minimax_input_modalities,
     normalize_provider,
     resolve_minimax_region,
     resolve_minimax_thinking_mode,
@@ -47,6 +50,62 @@ class TestLLMProvider(unittest.TestCase):
 
     def test_thinking_mode_unknown_model(self):
         self.assertIsNone(resolve_minimax_thinking_mode("unknown-model", True))
+
+    def test_minimax_model_input_modalities(self):
+        self.assertEqual(
+            MINIMAX_MODEL_INPUT_MODALITIES["MiniMax-M3"],
+            ("text", "image", "video"),
+        )
+        self.assertEqual(minimax_input_modalities("MiniMax-M2.7"), ("text",))
+
+    def test_multimodal_message_formats_image_input(self):
+        self.assertEqual(
+            build_multimodal_message(
+                "minimax",
+                "MiniMax-M3",
+                "Describe this image",
+                "encoded-image",
+                "image",
+            ),
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Describe this image"},
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": "data:image/png;base64,encoded-image"
+                            },
+                        },
+                    ],
+                }
+            ],
+        )
+
+    def test_multimodal_message_formats_video_input(self):
+        video_url = "https://media.example/video.mp4"
+        message = build_multimodal_message(
+            "minimax",
+            "MiniMax-M3",
+            "Summarize this video",
+            video_url,
+            "video",
+        )
+        self.assertEqual(
+            message[0]["content"][1],
+            {"type": "video_url", "video_url": {"url": video_url}},
+        )
+
+    def test_multimodal_message_rejects_unsupported_model_input(self):
+        with self.assertRaisesRegex(ValueError, "does not support 'video' input"):
+            build_multimodal_message(
+                "minimax",
+                "MiniMax-M2.7",
+                "Summarize this video",
+                "https://media.example/video.mp4",
+                "video",
+            )
 
     def test_extra_body_openai_default_matches_legacy_payload(self):
         self.assertEqual(


### PR DESCRIPTION
Reason: MiniMax-M3 supports text, image, and video chat input, but the existing VLM request path only formats images.

This change:

- registers each MiniMax model's accepted input modalities;
- builds validated text, image, and video content blocks;
- exposes a video URL path through the existing VLM helper while preserving image behavior; and
- adds focused tests for capability discovery, image formatting, video formatting, and unsupported video input.

Checks:

- `python3 -m unittest tests.unit.test_llm_provider`
- `python3 -m compileall -q openlens_ai/utils/llm_provider.py openlens_ai/utils/vision_feedback.py tests/unit/test_llm_provider.py`
- `git diff --check`
